### PR TITLE
Fixes  required positional argument: 'description' when label is empty

### DIFF
--- a/src/labels/github.py
+++ b/src/labels/github.py
@@ -17,8 +17,8 @@ class Label:
     """Represents a GitHub issue label."""
 
     color: str
-    description: str
     name: str
+    description: str = ""
 
     # Read-only attributes
     _default: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,13 +287,12 @@ def fixture_labels() -> typing.List[Label]:
         ),
         Label(
             color="f9d03b",
-            # description="",
-            name="nodesc"
+            name="no description"
         ),
         Label(
             color="f9d03b",
             description="",
-            name="emptydesc"
+            name="empty description"
         ),
     ]
 
@@ -337,15 +336,15 @@ def fixture_labels_file_content() -> typing.Dict[str, typing.Any]:
             "description": "Tasks related to Docker/CI etc.",
             "name": "infra",
         },
-        "nodesc": {
+        "no description": {
             "color": "f9d03b",
             "description": "",
-            "name": "nodesc",
+            "name": "no description",
         },
-        "emptydesc": {
+        "empty description": {
             "color": "f9d03b",
             "description": "",
-            "name": "emptydesc",
+            "name": "empty description",
         },
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -281,7 +281,19 @@ def fixture_labels() -> typing.List[Label]:
             name="good first issue",
         ),
         Label(
-            color="f9d03b", description="Tasks related to Docker/CI etc.", name="infra"
+            color="f9d03b",
+            description="Tasks related to Docker/CI etc.",
+            name="infra"
+        ),
+        Label(
+            color="f9d03b",
+            # description="",
+            name="nodesc"
+        ),
+        Label(
+            color="f9d03b",
+            description="",
+            name="emptydesc"
         ),
     ]
 
@@ -324,6 +336,16 @@ def fixture_labels_file_content() -> typing.Dict[str, typing.Any]:
             "color": "f9d03b",
             "description": "Tasks related to Docker/CI etc.",
             "name": "infra",
+        },
+        "nodesc": {
+            "color": "f9d03b",
+            "description": "",
+            "name": "nodesc",
+        },
+        "emptydesc": {
+            "color": "f9d03b",
+            "description": "",
+            "name": "emptydesc",
         },
     }
 

--- a/tests/labels.toml
+++ b/tests/labels.toml
@@ -33,12 +33,11 @@ color = "f9d03b"
 description = "Tasks related to Docker/CI etc."
 name = "infra"
 
-[nodesc]
+["no description"]
 color = "f9d03b"
-# No description
-name = "nodesc"
+name = "no description"
 
-[emptydesc]
+["empty description"]
 color = "f9d03b"
 description = ""
-name = "emptydesc"
+name = "empty description"

--- a/tests/labels.toml
+++ b/tests/labels.toml
@@ -32,3 +32,13 @@ name = "good first issue"
 color = "f9d03b"
 description = "Tasks related to Docker/CI etc."
 name = "infra"
+
+[nodesc]
+color = "f9d03b"
+# No description
+name = "nodesc"
+
+[emptydesc]
+color = "f9d03b"
+description = ""
+name = "emptydesc"

--- a/tests/sync.toml
+++ b/tests/sync.toml
@@ -1,14 +1,14 @@
 [bug]
 color = "fcc4db"
-description = "Bugs and problems with cookiecutter"
 name = "bug"
+description = "Bugs and problems with cookiecutter"
 
 [dependencies]
 color = "43a2b7"
-description = "Tasks related to managing dependencies"
 name = "dependencies"
+description = "Tasks related to managing dependencies"
 
 [docs]
 color = "2abf88"
-description = "Tasks to write and update documentation"
 name = "docs"
+description = "Tasks to write and update documentation"

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py36,mypy,flake8
 deps =
     pytest
     responses
-commands = pytest {posargs:tests}
+commands = pytest {posargs:tests} -v
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
When description is null, sync fails with error
```
Traceback (most recent call last):
  File "/usr/local/bin/labels", line 10, in <module>
    sys.exit(labels())
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/decorators.py", line 27, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/labels/cli.py", line 106, in sync_cmd
    local_labels = read_labels(filename)
  File "/usr/local/lib/python3.6/site-packages/labels/io.py", line 28, in read_labels
    return {name: Label(**values) for name, values in obj.items()}
  File "/usr/local/lib/python3.6/site-packages/labels/io.py", line 28, in <dictcomp>
    return {name: Label(**values) for name, values in obj.items()}
TypeError: __init__() missing 1 required positional argument: 'description'
```
This fixes it by assigning an empty string for description by default.