### PR TITLE
Handle pagination

### DIFF
--- a/src/labels/github.py
+++ b/src/labels/github.py
@@ -69,6 +69,14 @@ class Client:
             f"{self.base_url}/repos/{repo.owner}/{repo.name}/labels",
             headers={"Accept": "application/vnd.github.symmetra-preview+json"},
         )
+
+        if response.status_code != 200:
+            raise GitHubException(
+                f"Error retrieving labels: "
+                f"{response.status_code} - "
+                f"{response.reason}"
+            )
+
         json = response.json()
 
         next_page = response.links.get('next', None)
@@ -78,15 +86,16 @@ class Client:
                     next_page['url'],
                     headers={"Accept": "application/vnd.github.symmetra-preview+json"},
             )
+
+            if response.status_code != 200:
+                raise GitHubException(
+                    f"Error retrieving next page of labels: "
+                    f"{response.status_code} - "
+                    f"{response.reason}"
+                )
+
             json.extend(response.json())
             next_page = response.links.get('next', None)
-
-        if response.status_code != 200:
-            raise GitHubException(
-                f"Error retrieving labels: "
-                f"{response.status_code} - "
-                f"{response.reason}"
-            )
 
         return [Label(**data) for data in json]
 

--- a/src/labels/github.py
+++ b/src/labels/github.py
@@ -81,7 +81,7 @@ class Client:
                     headers={"Accept": "application/vnd.github.symmetra-preview+json"},
             )
             json.extend(response.json())
-            link_header = response.headers.get('Link')
+            link_header = response.headers.get('Link', '')
             next_page = [l for l in link_header.split(',') if 'rel="next"' in l]
 
         if response.status_code != 200:

--- a/src/labels/github.py
+++ b/src/labels/github.py
@@ -71,18 +71,15 @@ class Client:
         )
         json = response.json()
 
-        link_header = response.headers.get('Link', [])
-        next_page = [l for l in link_header.split(',') if 'rel="next"' in l]
+        next_page = response.links.get('next', None)
         while next_page:
-            l, _ = next_page[0].split(';')
-            logger.debug(f"Requesting {l.split('?')[1]}")
+            logger.debug(f"Requesting {next_page}")
             response = self.session.get(
-                    l[1:-1],
+                    next_page['url'],
                     headers={"Accept": "application/vnd.github.symmetra-preview+json"},
             )
             json.extend(response.json())
-            link_header = response.headers.get('Link', '')
-            next_page = [l for l in link_header.split(',') if 'rel="next"' in l]
+            next_page = response.links.get('next', None)
 
         if response.status_code != 200:
             raise GitHubException(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,31 @@ def fixture_mock_list_labels(
         yield
 
 
+@pytest.fixture(name="mock_paged_list_labels")
+def fixture_mock_paged_list_labels(
+    base_url: str, repo_owner: str, repo_name: str, response_list_labels: ResponseLabels
+) -> None:
+    """Mock requests for list labels."""
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            f"{base_url}/repos/{repo_owner}/{repo_name}/labels",
+            json=response_list_labels[:2],
+            status=200,
+            content_type="application/json",
+            headers={'link': f'<{base_url}/repos/{repo_owner}/{repo_name}/labels?page=2&per_page=2>; rel="next", <{base_url}/repos/{repo_owner}/{repo_name}/labels?page=2&per_page=2>; rel="last"'}  # noqa: E501
+        )
+        rsps.add(
+            responses.GET,
+            f"{base_url}/repos/{repo_owner}/{repo_name}/labels",
+            json=response_list_labels[2:],
+            status=200,
+            content_type="application/json",
+            headers={'link': f'<{base_url}/repos/{repo_owner}/{repo_name}/labels?page=1&per_page=2>; rel="prev", <{base_url}/repos/{repo_owner}/{repo_name}/labels?page=1&per_page=2>; rel="first"'}  # noqa: E501
+        )
+        yield
+
+
 @pytest.fixture(name="mock_get_label")
 def fixture_mock_get_label(
     base_url: str, repo_owner: str, repo_name: str, response_get_bug: ResponseLabel

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -17,7 +17,7 @@ def fixture_repo(repo_owner: str, repo_name: str) -> Repository:
     return Repository(repo_owner, repo_name)
 
 
-@pytest.mark.usefixtures("mock_list_labels")
+@pytest.mark.usefixtures("mock_paged_list_labels")
 def test_list_labels(client: Client, repo: Repository) -> None:
     """Test that list_labels() requests the labels for the specified repo and
     returns a list of Label instances.


### PR DESCRIPTION
Handle repositories with more labels than fit on a single page.
Without this, there's the risk of deleting labels that weren't retrieved. 