### PR TITLE
Tolerate description=None and make cli debuggable

### DIFF
--- a/src/labels/cli.py
+++ b/src/labels/cli.py
@@ -281,3 +281,7 @@ def dryrun_echo(
         click.echo("This would NOT modify the following labels:")
         for name in labels_to_ignore:
             click.echo(f"  - {name}")
+
+
+if __name__ == '__main__':
+    labels()

--- a/src/labels/github.py
+++ b/src/labels/github.py
@@ -26,7 +26,10 @@ class Label:
 
     color: str
     name: str
-    description: str = ""
+    description: str = attr.field(
+        default="",
+        converter=attr.converters.default_if_none("")
+    )
 
     # Read-only attributes
     _default: bool = False


### PR DESCRIPTION
Normally the github-API returns for an empty description `"description"=""`. But in rare occasions it returns for an empty description `"description"=None`. The value `None` causes an error when writing the toml-file (`TypeError: Object of type <class 'NoneType'> is not TOML serializable`). A description value of `None` may results from adding labels via the github-API with other tools (in my case [piceaTech/node-gitlab-2-github](https://github.com/piceaTech/node-gitlab-2-github)). - This PR adds auto-conversion of `None` to `""` to avoid the problem.

This PR also adds `if __name__ == "__main__": ...` to `cli.py` to enable running the script in the debugger via `python -m pdb src/labels/cli.py`.

