### PR TITLE
Fix typo in exception

### DIFF
--- a/src/labels/cli.py
+++ b/src/labels/cli.py
@@ -64,7 +64,7 @@ def default_owner(labels_context: LabelsContext) -> str:
         repository = utils.load_repository_info()
         if repository is None:
             raise click.BadParameter(
-                "Unable to read respository owner from git remote URL."
+                "Unable to read repository owner from git remote URL."
             )
         labels_context.repository = repository
     return labels_context.repository.owner


### PR DESCRIPTION
While contributing to https://github.com/hackebrot/labels/pull/36 I noticed a typo in an exception. 

<details>
<summary>Original content</summary>

Before making a PR please make sure to read our [contributing guidelines][contributing].

Please note that **labels** is released with a [Contributor Code of Conduct][code of conduct]. By participating in this project you agree to abide by its terms.

[code of conduct]: /CODE_OF_CONDUCT.md
[contributing]: /.github/CONTRIBUTING.md

</details>
