### PR TITLE
Fix links in PR templates to work in the context of a pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,5 @@ Before making a PR please make sure to read our [contributing guidelines][contri
 
 Please note that **labels** is released with a [Contributor Code of Conduct][code of conduct]. By participating in this project you agree to abide by its terms.
 
-[code of conduct]: /CODE_OF_CONDUCT.md
-[contributing]: /.github/CONTRIBUTING.md
+[code of conduct]: https://github.com/hackebrot/labels/blob/main/CODE_OF_CONDUCT.md
+[contributing]: https://github.com/hackebrot/labels/blob/main/.github/CONTRIBUTING.md


### PR DESCRIPTION
I noticed that the links in the body below aren't working in the context of a pull request, which is where (I think) they are the most useful. They go to:

- `https://github.com/.github/CONTRIBUTING.md`
- `https://github.com/CODE_OF_CONDUCT.md`

I don't think there is another way to fix them than making them absolute.

---

Before making a PR please make sure to read our [contributing guidelines][contributing].

Please note that **labels** is released with a [Contributor Code of Conduct][code of conduct]. By participating in this project you agree to abide by its terms.

[code of conduct]: /CODE_OF_CONDUCT.md
[contributing]: /.github/CONTRIBUTING.md
